### PR TITLE
Fix link to section in docs

### DIFF
--- a/docs/topics/mailbox_types.rst
+++ b/docs/topics/mailbox_types.rst
@@ -6,9 +6,9 @@ Django Mailbox supports polling both common internet mailboxes like POP3 and IMA
 
 .. table:: 'Protocol' Options
 
-  ============ ============== ===============================================================
+  ============ ============== ===============================================
   Mailbox Type 'Protocol'://  Notes
-  ============ ============== ===============================================================
+  ============ ============== ===============================================
   POP3         ``pop3://``    Can also specify SSL with ``pop3+ssl://``
   IMAP         ``imap://``    Can also specify SSL with ``imap+ssl://``
   Maildir      ``maildir://``
@@ -16,8 +16,8 @@ Django Mailbox supports polling both common internet mailboxes like POP3 and IMA
   Babyl        ``babyl://``
   MH           ``mh://``
   MMDF         ``mmdf://``
-  Piped Mail   *empty*        See `Receiving mail directly from Exim4 or Postfix via a pipe`_
-  ============ ============== ===============================================================
+  Piped Mail   *empty*        See :ref:`receiving-mail-from-exim4-or-postfix`
+  ============ ============== ===============================================
 
 .. WARNING::
    This will delete any messages it can find in the inbox you specify; 

--- a/docs/topics/polling.rst
+++ b/docs/topics/polling.rst
@@ -29,6 +29,8 @@ You can easily consume incoming mail by running the management command named ``g
     python manage.py getmail
 
 
+.. _receiving-mail-from-exim4-or-postfix:
+
 Receiving mail directly from Exim4 or Postfix via a pipe
 --------------------------------------------------------
 


### PR DESCRIPTION
Link in [table](https://django-mailbox.readthedocs.org/en/latest/topics/mailbox_types.html#supported-mailbox-types) points into empty space.
