### PR TITLE
Fix deprecation warnings after Django 1.7 upgrade

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -75,7 +75,7 @@ ATTACHMENT_INTERPOLATION_HEADER = getattr(
 
 class ActiveMailboxManager(models.Manager):
     def get_queryset(self):
-        return super(ActiveMailboxManager, self).get_query_set().filter(
+        return super(ActiveMailboxManager, self).get_queryset().filter(
             active=True,
         )
 
@@ -352,21 +352,21 @@ class Mailbox(models.Model):
 
 class IncomingMessageManager(models.Manager):
     def get_queryset(self):
-        return super(IncomingMessageManager, self).get_query_set().filter(
+        return super(IncomingMessageManager, self).get_queryset().filter(
             outgoing=False,
         )
 
 
 class OutgoingMessageManager(models.Manager):
     def get_queryset(self):
-        return super(OutgoingMessageManager, self).get_query_set().filter(
+        return super(OutgoingMessageManager, self).get_queryset().filter(
             outgoing=True,
         )
 
 
 class UnreadMessageManager(models.Manager):
     def get_queryset(self):
-        return super(UnreadMessageManager, self).get_query_set().filter(
+        return super(UnreadMessageManager, self).get_queryset().filter(
             read=None
         )
 


### PR DESCRIPTION
After upgrading to Django 1.7 several deprecation warnings are now printed on startup.

<pre>
site-packages/django_mailbox/models.py:76: RemovedInDjango18Warning: `ActiveMailboxManager.get_query_set` method should be renamed `get_queryset`.
  class ActiveMailboxManager(models.Manager):

site-packages/django_mailbox/models.py:353: RemovedInDjango18Warning: `IncomingMessageManager.get_query_set` method should be renamed `get_queryset`.
  class IncomingMessageManager(models.Manager):

site-packages/django_mailbox/models.py:360: RemovedInDjango18Warning: `OutgoingMessageManager.get_query_set` method should be renamed `get_queryset`.
  class OutgoingMessageManager(models.Manager):

site-packages/django_mailbox/models.py:367: RemovedInDjango18Warning: `UnreadMessageManager.get_query_set` method should be renamed `get_queryset`.
  class UnreadMessageManager(models.Manager):
</pre>
