### PR TITLE
If no message_ids, return before checking for small_message_ids

### DIFF
--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -72,12 +72,12 @@ class ImapTransport(EmailTransport):
     def get_message(self):
         message_ids = self._get_all_message_ids()
 
+        if not message_ids:
+            return
+
         # Limit the uids to the small ones if we care about that
         if self.max_message_size:
             message_ids = self._get_small_message_ids(message_ids)
-
-        if not message_ids:
-            return
 
         if self.archive:
             typ, folders = self.server.list(pattern=self.archive)


### PR DESCRIPTION
Hey,

I'm having an issue with 4.2. It looks similar to [Issue #24] (https://github.com/coddingtonbear/django-mailbox/issues/24).

If DJANGO_MAILBOX_MAX_MESSAGE_SIZE is enabled and there's no new messages it produces:

```python
  File "/home/vagrant/venv2/local/lib/python2.7/site-packages/django_mailbox/management/commands/getmail.py", line 24, in handle
    messages = mailbox.get_new_mail()
  File "/home/vagrant/venv2/local/lib/python2.7/site-packages/django_mailbox/models.py", line 358, in get_new_mail
    for message in connection.get_message():
  File "/home/vagrant/venv2/local/lib/python2.7/site-packages/django_mailbox/transports/imap.py", line 77, in get_message
    message_ids = self._get_small_message_ids(message_ids)
  File "/home/vagrant/venv2/local/lib/python2.7/site-packages/django_mailbox/transports/imap.py", line 56, in _get_small_message_ids
    '(RFC822.SIZE)'
  File "/usr/lib/python2.7/imaplib.py", line 772, in uid
    typ, dat = self._simple_command(name, command, *args)
  File "/usr/lib/python2.7/imaplib.py", line 1087, in _simple_command
    return self._command_complete(name, self._command(name, *args))
  File "/usr/lib/python2.7/imaplib.py", line 917, in _command_complete
    raise self.error('%s command error: %s %s' % (name, typ, data))
imaplib.error: UID command error: BAD ['Could not parse command']
```

```python
        message_ids = self._get_all_message_ids()

        # Limit the uids to the small ones if we care about that
        if self.max_message_size:
            message_ids = self._get_small_message_ids(message_ids)

        if not message_ids:
            return
```

Looks like the issue is here. If `message_ids = []` and there's a `max_message_size` then `self._get_small_message_ids(message_ids)` fails. Maybe 
```python
        if not message_ids:
            return
```
 should be moved in front of `self._get_small_message_ids(message_ids)` because we don't need to find the small message ids if no message ids exist.
