### PR TITLE
During reply update from_email only if not set; store original e-mail contents on-disk if requested

### DIFF
--- a/django_mailbox/migrations/0002_add_eml_to_message.py
+++ b/django_mailbox/migrations/0002_add_eml_to_message.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='message',
             name='eml',
-            field=models.FileField(help_text='Original full content of message', upload_to=b'', null=True, verbose_name='Message as a file'),
+            field=models.FileField(help_text='Original full content of message', upload_to=b'messages', null=True, verbose_name='Message as a file'),
             preserve_default=True,
         ),
     ]

--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -511,7 +511,7 @@ class Message(models.Model):
         pre-set it.
 
         """
-        if not self.from_email:
+        if not message.from_email:
             if self.mailbox.from_email:
                 message.from_email = self.mailbox.from_email
             else:

--- a/django_mailbox/tests/test_process_email.py
+++ b/django_mailbox/tests/test_process_email.py
@@ -210,7 +210,7 @@ class TestProcessEmail(EmailMessageTestCase):
         )
         msg = self.mailbox.record_outgoing_message(email_object.message())
 
-        self.assertEqual(msg.outgoing, True)
+        self.assertTrue(msg.outgoing)
 
         actual_from = 'username@example.com'
         reply_email_object = EmailMessage('Test subject',  # subject

--- a/docs/topics/appendix/settings.rst
+++ b/docs/topics/appendix/settings.rst
@@ -66,6 +66,7 @@ Settings
   * If this is set, it will be read as a number of
     bytes.  Any messages above that size will not be
     downloaded.  ``2000000`` is 2 Megabytes.
+
 * ``DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE``
   * Default: ``False``
   * Type: ``boolean``


### PR DESCRIPTION
Hello,

I don't see any reason to force update from_email if I set explite it. I use from_email to assosiate outgoing email with incoming (headers are not enought), so I have to set from_email handsome.

Greetings,
Adam Dobrawy