### PR TITLE
Turn on exception for incoming messages

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -260,11 +260,8 @@ class Mailbox(models.Model):
         msg.outgoing = False
         msg.save()
 
-        try:
-            message_received.send(sender=self, message=msg)
-        except:
-            pass
-
+        message_received.send(sender=self, message=msg)
+        
         return msg
 
     def record_outgoing_message(self, message):


### PR DESCRIPTION
> Errors should never pass silently

I waste a hours to debug that . I don't expect this kind of behaviour. In my app proccess incoming mails is critical and I should receive exception and on fail transaction should rollback everything and try again later.