### PR TITLE
Add pip cache and cointaner mode to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: false
+cache: pip
 python:
 - '2.6'
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   - env: DJANGO=1.8.2
     python: '2.6'
 install:
-- pip install pip wheel -u
+- pip install -U pip wheel
 - pip install -q Django==$DJANGO
 - pip install -q -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ matrix:
   - env: DJANGO=1.8.2
     python: '2.6'
 install:
-- pip install -q Django==$DJANGO --use-mirrors
-- pip install -q -e . --use-mirrors
+- pip install pip wheel -u
+- pip install -q Django==$DJANGO
+- pip install -q -e .
 script:
 - python setup.py test


### PR DESCRIPTION
Pip caching is described in http://docs.travis-ci.com/user/caching/ . We will not need redownload dependencies every time. It will work faster.

Container-based infrastructure is described in http://docs.travis-ci.com/user/migrating-from-legacy/. We can freely migrate to container-based infrastructure. It will work faster too.