### PR TITLE
Fix typo in docs list near DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE

### DIFF
--- a/docs/topics/appendix/settings.rst
+++ b/docs/topics/appendix/settings.rst
@@ -76,6 +76,7 @@ Settings
     downloaded.  ``2000000`` is 2 Megabytes.
 
 * ``DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE``
+
   * Default: ``False``
   * Type: ``boolean``
   * Controls whether or not we store original messages in ``eml`` field


### PR DESCRIPTION

![zaznaczenie_399](https://cloud.githubusercontent.com/assets/3618479/9456916/e286510e-4add-11e5-9a83-445b4ae02016.png)
The list was not parsed as list.

Hop, it will help.