### PR TITLE
Use ugettext_lazy instead ugettext in models.py

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -24,7 +24,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.mail.message import make_msgid
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .utils import convert_header_to_unicode, get_body_from_message
 from django_mailbox.signals import message_received


### PR DESCRIPTION
Hello,

I am have issues with django_mailbox. If I switch default django language, translate any sentences which exists in django_mailbox too, django detect new migrations and create them. In migrations we have translated field name. It is a side effect. 

Any translations should don't cause new migrations.

We should use ugettext_lazy in models.py. Django docs recommend it too ( https://docs.djangoproject.com/en/1.8/topics/i18n/translation/ ).

Greetings,
