### PR TITLE
Fixed encoding error when saving messages to file (fixes #85)

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -362,7 +362,7 @@ class Mailbox(models.Model):
     def _process_message(self, message):
         msg = Message()
         if STORE_ORIGINAL_MESSAGE:
-            msg.eml.save('%s.eml' % uuid.uuid4(), ContentFile(message), save=False)
+            msg.eml.save('%s.eml' % uuid.uuid4(), ContentFile(message.as_string(unixfrom=True)), save=False)
         msg.mailbox = self
         if 'subject' in message:
             msg.subject = convert_header_to_unicode(message['subject'])[0:255]


### PR DESCRIPTION
Fixes #85 by converting the `Message` object to string before putting it into a `ContentFile`.

A better fix than #86 as it uses the `as_string` method on `email.message.Message`.