### PR TITLE
Clean up EmailMessageTestCase._get_email_as_text

### DIFF
--- a/django_mailbox/tests/base.py
+++ b/django_mailbox/tests/base.py
@@ -59,7 +59,7 @@ class EmailMessageTestCase(TestCase):
             time.sleep(5)
 
     def _get_email_object(self, name):
-        with open(join(dirname(__file__), 'messages', name), 'rb') as f:
+        with open(join(dirname(__file__), 'messages', name), 'r') as f:
             if six.PY3:
                 return email.message_from_binary_file(f)
             else:

--- a/django_mailbox/tests/base.py
+++ b/django_mailbox/tests/base.py
@@ -15,7 +15,7 @@ class EmailIntegrationTimeout(Exception):
 
 
 def get_email_as_text(name):
-    with open(join(dirname(__file__), 'messages', name), 'rb') as f:
+    with open(join(dirname(__file__), 'messages', name), 'r') as f:
         return f.read()
 
 

--- a/django_mailbox/tests/base.py
+++ b/django_mailbox/tests/base.py
@@ -59,7 +59,7 @@ class EmailMessageTestCase(TestCase):
 
     def _get_email_object(self, name):
         with open(join(dirname(__file__), 'messages', name), 'rb') as f:
-            return email.message_from_files(f)
+            return email.message_from_file(f)
 
     def _headers_identical(self, left, right, header=None):
         """ Check if headers are (close enough to) identical.

--- a/django_mailbox/tests/base.py
+++ b/django_mailbox/tests/base.py
@@ -2,6 +2,7 @@ import email
 import os
 from os.path import dirname, join
 import time
+import six
 
 from django.conf import settings
 from django.test import TestCase
@@ -59,7 +60,10 @@ class EmailMessageTestCase(TestCase):
 
     def _get_email_object(self, name):
         with open(join(dirname(__file__), 'messages', name), 'rb') as f:
-            return email.message_from_file(f)
+            if six.PY3:
+                return email.message_from_binary_file(f)
+            else:
+                return email.message_from_file(f)
 
     def _headers_identical(self, left, right, header=None):
         """ Check if headers are (close enough to) identical.

--- a/django_mailbox/tests/base.py
+++ b/django_mailbox/tests/base.py
@@ -1,8 +1,7 @@
 import email
-import os.path
+import os
+from os.path import dirname, join
 import time
-
-import six
 
 from django.conf import settings
 from django.test import TestCase
@@ -16,14 +15,7 @@ class EmailIntegrationTimeout(Exception):
 
 
 def get_email_as_text(name):
-    with open(
-        os.path.join(
-            os.path.dirname(__file__),
-            'messages',
-            name,
-        ),
-        'rb'
-    ) as f:
+    with open(join(dirname(__file__), 'messages', name), 'rb') as f:
         return f.read()
 
 
@@ -65,23 +57,9 @@ class EmailMessageTestCase(TestCase):
                 return messages
             time.sleep(5)
 
-    def _get_email_as_text(self, name):
-        with open(
-            os.path.join(
-                os.path.dirname(__file__),
-                'messages',
-                name,
-            ),
-            'rb'
-        ) as f:
-            return f.read()
-
     def _get_email_object(self, name):
-        copy = self._get_email_as_text(name)
-        if six.PY3:
-            return email.message_from_bytes(copy)
-        else:
-            return email.message_from_string(copy)
+        with open(join(dirname(__file__), 'messages', name), 'rb') as f:
+            return email.message_from_files(f)
 
     def _headers_identical(self, left, right, header=None):
         """ Check if headers are (close enough to) identical.

--- a/django_mailbox/tests/test_transports.py
+++ b/django_mailbox/tests/test_transports.py
@@ -148,7 +148,7 @@ class TestPop3Transport(EmailMessageTestCase):
                 '+OK message follows',
                 [
                     line.encode('ascii')
-                    for line in self._get_email_as_text(
+                    for line in get_email_as_text(
                         'generic_message.eml'
                     ).decode('ascii').split('\n')
                 ],


### PR DESCRIPTION
Hello,

I would like remove some duplication of code. I think better to use  ```email.message_from_files``` than pass string read independently too.

Greetings,