### PR TITLE
add imaps STARTTLS support

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -194,6 +194,11 @@ class Mailbox(models.Model):
         return '+ssl' in self._protocol_info.scheme.lower()
 
     @property
+    def use_tls(self):
+        """Returns whether or not this mailbox's connection uses STARTTLS."""
+        return '+tls' in self._protocol_info.scheme.lower()
+
+    @property
     def archive(self):
         """Returns (if specified) the folder to archive messages to."""
         archive_folder = self._query_string.get('archive', None)
@@ -223,6 +228,7 @@ class Mailbox(models.Model):
                 self.location,
                 port=self.port if self.port else None,
                 ssl=self.use_ssl,
+                tls=self.use_tls,
                 archive=self.archive,
                 folder=self.folder
             )

--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 class ImapTransport(EmailTransport):
     def __init__(
-        self, hostname, port=None, ssl=False, archive='', folder=None
+        self, hostname, port=None, ssl=False, tls=False,
+        archive='', folder=None,
     ):
         self.max_message_size = getattr(
             settings,
@@ -34,6 +35,7 @@ class ImapTransport(EmailTransport):
         self.port = port
         self.archive = archive
         self.folder = folder
+        self.tls = tls
         if ssl:
             self.transport = imaplib.IMAP4_SSL
             if not self.port:
@@ -45,6 +47,8 @@ class ImapTransport(EmailTransport):
 
     def connect(self, username, password):
         self.server = self.transport(self.hostname, self.port)
+        if self.tls:
+            self.server.starttls()
         typ, msg = self.server.login(username, password)
 
         if self.folder:

--- a/docs/topics/mailbox_types.rst
+++ b/docs/topics/mailbox_types.rst
@@ -7,11 +7,11 @@ POP3 and IMAP as well as local file-based mailboxes.
 
 .. table:: 'Protocol' Options
 
-  ============ ================ =================================================================================================================================================================
+  ============ ================ ====================================================================================================================================================================
   Mailbox Type 'Protocol'://    Notes
-  ============ ================ =================================================================================================================================================================
+  ============ ================ ====================================================================================================================================================================
   POP3         ``pop3://``      Can also specify SSL with ``pop3+ssl://``
-  IMAP         ``imap://``      Can also specify SSL with ``imap+ssl://``; additional configuration is also possible: see :ref:`pop3-and-imap-mailboxes` for details.
+  IMAP         ``imap://``      Can also specify SSL with ``imap+ssl://`` or STARTTLS with ``imap+tls``; additional configuration is also possible: see :ref:`pop3-and-imap-mailboxes` for details.
   Gmail IMAP   ``gmail+ssl://`` Uses OAuth authentication for  Gmail's IMAP transport.  See :ref:`gmail-oauth` for details.
   Maildir      ``maildir://``
   Mbox         ``mbox://``
@@ -19,7 +19,7 @@ POP3 and IMAP as well as local file-based mailboxes.
   MH           ``mh://``
   MMDF         ``mmdf://``
   Piped Mail   *empty*          See :ref:`receiving-mail-from-exim4-or-postfix`
-  ============ ================ =================================================================================================================================================================
+  ============ ================ ====================================================================================================================================================================
 
 
 .. warning::
@@ -42,8 +42,9 @@ Basic IMAP Example: ``imap://username:password@server``
 
 Basic POP3 Example: ``pop3://username:password@server``
 
-Most mailboxes these days are SSL-enabled; 
-if yours is, add ``+ssl`` to the protocol section of your URI.  
+Most mailboxes these days are SSL-enabled;
+if yours use plain SSL add ``+ssl`` to the protocol section of your URI,
+but for STARTTLS add ``+tls``.
 Also, if your username or password include any non-ascii characters,
 they should be URL-encoded  (for example, if your username includes an
 ``@``, it should be changed to ``%40`` in your URI).


### PR DESCRIPTION
This pull request add imap connection using [STARTTLS][dw], which as you can read is different from a simple SSL connection

Use `imaps` as protocol for this feature

[dw]: http://wiki.dovecot.org/SSL "Dovecot wiki SSL"