### PR TITLE
python3 support for `rfc822.parseaddr`

### DIFF
--- a/django_mailbox/management/commands/processincomingmessage.py
+++ b/django_mailbox/management/commands/processincomingmessage.py
@@ -1,7 +1,10 @@
 import email
 import logging
-import rfc822
 import sys
+try:
+    from email import utils
+except ImportError:
+    import rfc822 as utils
 
 from django.core.management.base import BaseCommand
 
@@ -38,5 +41,5 @@ class Command(BaseCommand):
         return mailbox
 
     def get_mailbox_for_message(self, message):
-        email_address = rfc822.parseaddr(message['to'])[1][0:255]
+        email_address = utils.parseaddr(message['to'])[1][0:255]
         return self.get_mailbox_by_name(email_address)


### PR DESCRIPTION
`rfc822` module has been supplanted by email during [python3 stdlib porting](http://python3porting.com/stdlib.html) 

According [rfc822.parseaddr documentation](https://docs.python.org/2/library/rfc822.html#rfc822.parseaddr) it appears that this function as been replace by [email.utils.parseaddr](https://docs.python.org/3/library/email.util.html#email.utils.parseaddr)

imho python3 is the future -present?- so I put it as the default choice with a fallback to python2