### PR TITLE
Auto-add model fields as param in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,5 +242,55 @@ texinfo_documents = [
 #texinfo_show_urls = 'footnote'
 
 sys.path.insert(0, os.path.abspath('..'))
+import inspect
+import django
+from django.utils.html import strip_tags
+from django.utils.encoding import force_text
 from django.conf import settings
-settings.configure()
+settings.configure(INSTALLED_APPS=['django_mailbox', ])
+django.setup()
+
+def process_docstring(app, what, name, obj, options, lines):
+    # Source: https://gist.github.com/abulka/48b54ea4cbc7eb014308
+    # This causes import errors if left outside the function
+    from django.db import models
+
+    # Only look at objects that inherit from Django's base model class
+    if inspect.isclass(obj) and issubclass(obj, models.Model):
+        # Grab the field list from the meta class
+        fields = obj._meta.get_fields()
+
+        for field in fields:
+            # Skip ManyToOneRel and ManyToManyRel fields which have no 'verbose_name' or 'help_text'
+            if not hasattr(field, 'verbose_name'):
+                continue
+
+            # Decode and strip any html out of the field's help text
+            help_text = strip_tags(force_text(field.help_text))
+
+            # Decode and capitalize the verbose name, for use if there isn't
+            # any help text
+            verbose_name = force_text(field.verbose_name).capitalize()
+
+            if help_text:
+                # Add the model field to the end of the docstring as a param
+                # using the help text as the description
+                lines.append(u':param %s: %s' % (field.attname, help_text))
+            else:
+                # Add the model field to the end of the docstring as a param
+                # using the verbose name as the description
+                lines.append(u':param %s: %s' % (field.attname, verbose_name))
+
+            # Add the field's type to the docstring
+            if isinstance(field, models.ForeignKey):
+                to = field.rel.to
+                lines.append(u':type %s: %s to :class:`~%s.%s`' % (field.attname, type(field).__name__, to.__module__, to.__name__))
+            else:
+                lines.append(u':type %s: %s' % (field.attname, type(field).__name__))
+
+    # Return the extended docstring
+    return lines
+
+def setup(app):
+    # Register the docstring processor with sphinx
+    app.connect('autodoc-process-docstring', process_docstring)


### PR DESCRIPTION
Hello,

I suggest auto-add model field as param in sphinx autoclass, so it produce output like:
![zaznaczenie_760](https://cloud.githubusercontent.com/assets/3618479/17689146/c7270a86-6385-11e6-8a13-6655383e3701.png)

Greetings,