### PR TITLE
ISSUES-129: Increased to FileField(max_length=2000) from max_length=1…

### DIFF
--- a/django_mailbox/__init__.py
+++ b/django_mailbox/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '4.5.4'
+__version__ = '4.5.4-issues129'

--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -482,6 +482,7 @@ class Message(models.Model):
 
     eml = models.FileField(
         _(u'Raw message contents'),
+        max_length=2000,
         null=True,
         upload_to="messages",
         help_text=_(u'Original full content of message')
@@ -717,6 +718,7 @@ class MessageAttachment(models.Model):
 
     document = models.FileField(
         _(u'Document'),
+        max_length=2000,
         upload_to=utils.get_attachment_save_path,
     )
 


### PR DESCRIPTION
…00 which was too short.

The MailAttachment.document field is too short & raises the error below. The default FileField(..., max_length=100) does not hold long enough filenames.
Can MailAttachment.document accept a configured max_length, or have the default set higher?

ERROR: [django.security.SuspiciousFileOperation: 204] Storage can not find an available filename Please make sure that the corresponding file field allows sufficient "max_length".