### PR TITLE
Remove null=True for Mailbox.uri and Mailbox.from_email

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -64,7 +64,6 @@ class Mailbox(models.Model):
             "contain illegal characters (like @, :, etc)."
         )),
         blank=True,
-        null=True,
         default=None,
     )
 
@@ -81,7 +80,6 @@ class Mailbox(models.Model):
             "be set to match the setting `DEFAULT_FROM_EMAIL`."
         )),
         blank=True,
-        null=True,
         default=None,
     )
 


### PR DESCRIPTION
According to Django's docs it's advised to not use null for string fields.