### PR TITLE
Cache email object in Message

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -345,6 +345,7 @@ class Mailbox(models.Model):
 
     def _process_message(self, message):
         msg = Message()
+        msg._email_object = message
         settings = utils.get_settings()
 
         if settings['store_original_message']:
@@ -710,20 +711,22 @@ class Message(models.Model):
            (https://docs.python.org/2/library/email.message.html)
 
         """
-        if self.eml:
-            if self.eml.name.endswith('.gz'):
-                body = gzip.GzipFile(fileobj=self.eml).read()
+        if not hasattr(self, '_email_object'):  # Cache fill
+            if self.eml:
+                if self.eml.name.endswith('.gz'):
+                    body = gzip.GzipFile(fileobj=self.eml).read()
+                else:
+                    self.eml.open()
+                    body = self.eml.file.read()
+                    self.eml.close()
             else:
-                self.eml.open()
-                body = self.eml.file.read()
-                self.eml.close()
-        else:
-            body = self.get_body()
-        if six.PY3:
-            flat = email.message_from_bytes(body)
-        else:
-            flat = email.message_from_string(body)
-        return self._rehydrate(flat)
+                body = self.get_body()
+            if six.PY3:
+                flat = email.message_from_bytes(body)
+            else:
+                flat = email.message_from_string(body)
+            self._email_object = self._rehydrate(flat)
+        return self._email_object
 
     def delete(self, *args, **kwargs):
         """Delete this message and all stored attachments."""

--- a/django_mailbox/tests/test_message_flattening.py
+++ b/django_mailbox/tests/test_message_flattening.py
@@ -64,6 +64,7 @@ class TestMessageFlattening(EmailMessageTestCase):
 
         msg = self.mailbox.process_incoming_message(incoming_email_object)
 
+        del msg._email_object  # Cache flush
         actual_email_object = msg.get_email_object()
 
         self.assertEqual(
@@ -89,6 +90,7 @@ class TestMessageFlattening(EmailMessageTestCase):
 
             msg = self.mailbox.process_incoming_message(incoming_email_object)
 
+        del msg._email_object  # Cache flush
         actual_email_object = msg.get_email_object()
 
         self.assertEqual(


### PR DESCRIPTION
Hello,

I suggest cache email object. It's important, due risk of storage latency and reduce IO. 

Now if new incoming processed and signals use property then message was loaded multiple times from disk (potentially in compressed form in addiction), next to ``text`` property load email object from disk. If someone uses the ``html`` property then the message is read from the disk even twice.

Greetings,