### PR TITLE
Add Django 2.x version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+
 env:
   matrix:
   - DJANGO='>=1.7,<1.8'
@@ -11,6 +12,7 @@ env:
   - DJANGO='>=1.9,<1.10'
   - DJANGO='>=1.10,<1.11'
   - DJANGO='>=1.11,<2.0'
+  - DJANGO='>=2.0,<2.1'
   global:
   - secure: aswHU7pQroGM+GHoYlhXzzk2FYfqxXJORjqXPsbgoHAIu4Bssaj8+YAzIcdy3j9kSt4I8VBpjnn8H/wzQXki75JBZOosQrIeMK018+uR+ZMONBLqDYW/N7EJHLgZt9QXxQNKeZygrD4GN/Dc4gLHGvPQC/RfPuuHcnF0Liaahoo=
   - secure: RZ6M6984P885GRoyx9n/WCCWGoFAzYpS8sZkXu3e/HK9oPXfaM2IEHjkq03jIC/FcWn/QMtFjOUBqQU94rnqdivFdFkeZHk1WUQgC0hztH3Qhh9zu2PNIrYUDpVD5dJqBpprWbSwFP8yNsJlP9A2RUubTlZblKHuaBhhiuNN+kU=
@@ -18,24 +20,29 @@ env:
   - secure: mMa7UUt+CQDB52fGM1T3oRL67OzQzRIc+BQCOqUEUhBV7p5g7Y1Hv6NTdVZTvK16x3DsP+5kFNd1v7rsTFw2qzP3hOxIv2BtMPuSzZdnN85Zd/nGwnztxzj/rqw7TMBaYvIdEZZbpRF/K0p0Xr6LJK2s9UkPXPUaLqly7kNi360=
 matrix:
   exclude:
-  - env: DJANGO='>=1.7,<1.8'
-    python: '2.6'
+# sort by django version, next to by python version
+# Django 1.7 support Python 2.7, 3.4
   - env: DJANGO='>=1.7,<1.8'
     python: '3.5'
   - env: DJANGO='>=1.7,<1.8'
     python: '3.6'
+# Django 1.8 support Python 2.7, 3.4, 3.5
   - env: DJANGO='>=1.8,<1.9'
-    python: '2.6'
+    python: '3.6'
+# Django 1.9 support Python 2.7, 3.4, 3.5
   - env: DJANGO='>=1.9,<1.10'
-    python: '2.6'
-  - env: DJANGO='>=1.9,<1.10'
-    python: '3.3'
-  - env: DJANGO='>=1.9,<1.10'
-    python: '3.4'
+    python: '3.6'
+# Django 1.10 support Python 2.7, 3.4, 3.5
+  - env: DJANGO='>=1.10,<1.11'
+    python: '3.6'
+# Django 1.11 support all supported Python interpreter
+# Django 2.0 support Python 3.4, 3.5, 3.6
+  - env: DJANGO='>=2.0,<2.1'
+    python: '2.7'
 install:
-- pip install -q Django$DJANGO
-- pip install -r test_requirements.txt
-- pip install -q -e .
+  - pip install -q Django$DJANGO
+  - pip install -r test_requirements.txt
+  - pip install -q -e .
 script:
-- python manage.py test
+  - python manage.py test
 sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,22 @@
 [tox]
-envlist=py27,py34,py35,flake8
+# sort by django version, next by python version
+envlist=
+    flake8
+    py{27,34}-django17
+    py{34,35}-django18
+    py{27,34,35}-django19
+    py{27,34,35}-django110
+    py{27,34,35,36}-django111
+    py{34,35,36}-django20
 
 [testenv]
 deps=
-    django
+    django17: django>=1.7,<1.8
+    django18: django>=1.8,<1.9
+    django19: django>=1.9,<1.10
+    django110: django>=1.10,<1.11
+    django111: django>=1.11,<2.0
+    django20: django>=2.0,<2.1
     -r{toxinidir}/test_requirements.txt
 sitepackages=False
 commands=


### PR DESCRIPTION
I have included all versions of the Python interpreter that are officially supported for the Django editions we support. A few were missing. I also added the missing 2.0 release for Django.

All tests for Django 2.0 pass.