### PR TITLE
Add makemigrations check in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,9 @@ deps=
     -r{toxinidir}/test_requirements.txt
 sitepackages=False
 commands=
+    django110: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django111: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django20: python {toxinidir}/manage.py makemigrations --check --dry-run
     python manage.py test {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
The change blocks the tests if there are pending migrations. It prevents oversight generate migration and ensures that migrations across all platforms behave consistently.