### PR TITLE
Handle missing content-transfer-encoding better.

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -372,8 +372,13 @@ class Mailbox(models.Model):
         except KeyError as exc:
             # email.message.replace_header may raise 'KeyError' if the header
             # 'content-transfer-encoding' is missing
-            logger.warning("Failed to parse message: %s", exc,)
-            return None
+            try:
+                # Before we give up, let's try mailman's approach:
+                #   https://bugs.python.org/msg308362
+                body = message.as_bytes(self).decode('ascii', 'replace')
+            except KeyError as exc:
+                logger.warning("Failed to parse message: %s", exc,)
+                return None
         msg.set_body(body)
         if message['in-reply-to']:
             try:


### PR DESCRIPTION
Improve the workaround of https://bugs.python.org/issue27321 in coddingtonbear#136,
using patch from https://bugs.python.org/msg308362.

Closes #201.