### PR TITLE
add to docs archive=myarchivefolder&folder=MyFolder

### DIFF
--- a/docs/topics/mailbox_types.rst
+++ b/docs/topics/mailbox_types.rst
@@ -93,6 +93,10 @@ after processing, add ``?archive=myarchivefolder`` to the end of the URI::
 
 .. _gmail-oauth:
 
+If you want to specifying both folder use ``&``::
+
+    imap+ssl://youremailaddress%40gmail.com:1234@imap.gmail.com?archive=myarchivefolder&folder=MyFolder
+
 Gmail IMAP with Oauth2 authentication
 -------------------------------------
 


### PR DESCRIPTION
Add information about use both folder for inbox and archive.
Sometimes it's not obvious, and you try incorrect ?archive=myarchivefolder?folder=MyFolder