### PR TITLE
add DJANGO_MAILBOX_MESSAGE_UPLOAD_TO to settings, change utils.get_at…

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -512,7 +512,7 @@ class Message(models.Model):
     eml = models.FileField(
         _('Raw message contents'),
         null=True,
-        upload_to="messages",
+        upload_to=utils.get_save_path(setting='message_upload_to'),
         help_text=_('Original full content of message')
     )
     objects = models.Manager()
@@ -752,7 +752,7 @@ class MessageAttachment(models.Model):
 
     document = models.FileField(
         _('Document'),
-        upload_to=utils.get_attachment_save_path,
+        upload_to=utils.get_save_path(setting='attachment_upload_to'),
     )
 
     def delete(self, *args, **kwargs):

--- a/django_mailbox/utils.py
+++ b/django_mailbox/utils.py
@@ -66,7 +66,13 @@ def get_settings():
             settings,
             'DJANGO_MAILBOX_default_charset',
             'iso8859-1',
+        ),
+        'message_upload_to': getattr(
+            settings,
+            'DJANGO_MAILBOX_MESSAGE_UPLOAD_TO',
+            'messages/'
         )
+
     }
 
 
@@ -138,10 +144,10 @@ def get_body_from_message(message, maintype, subtype):
     return body
 
 
-def get_attachment_save_path(instance, filename):
+def get_save_path(instance, filename, setting):
     settings = get_settings()
 
-    path = settings['attachment_upload_to']
+    path = settings[setting]
     if '%' in path:
         path = datetime.datetime.utcnow().strftime(path)
 

--- a/docs/topics/appendix/settings.rst
+++ b/docs/topics/appendix/settings.rst
@@ -80,3 +80,9 @@ Settings
   * Default: ``False``
   * Type: ``boolean``
   * Controls whether or not we store original messages in ``eml`` field
+
+* ``DJANGO_MAILBOX_MESSAGE_UPLOAD_TO``
+
+  * Default: ``messages/``
+  * Type: ``string``
+  * Original message will be saved to this location.


### PR DESCRIPTION
By default original message eml store in 'messages/' if _DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE_ == True
But there are no path settings for **eml** like for **attachment**.
Add **DJANGO_MAILBOX_MESSAGE_UPLOAD_TO** setting, rewrite **get_attachment_save_path** > **get_save_path** in utils.py, edit **upload_to**  in model for Message.eml and MessageAttachment.document