### PR TITLE
Fix reading message id and size when returned in reversed order by IMAP server

### DIFF
--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -82,8 +82,14 @@ class ImapTransport(EmailTransport):
         for each_msg in data:
             each_msg = each_msg.decode()
             try:
-                uid = each_msg.split(' ')[2]
-                size = each_msg.split(' ')[4].rstrip(')')
+                stripped_msg = each_msg.replace('(', '').replace(')', '')
+                split_msg = stripped_msg.split(' ')
+                for i, s in enumerate(split_msg):
+                    if s == 'UID':
+                        uid = split_msg[i + 1]
+                    elif s == 'RFC822.SIZE':
+                        size = split_msg[i + 1]
+
                 if int(size) <= int(self.max_message_size):
                     safe_message_ids.append(uid)
             except ValueError as e:


### PR DESCRIPTION
Fixes IMAP to work with Office365 (outlook.office365.com) when using `DJANGO_MAILBOX_MAX_MESSAGE_SIZE` option.

To reproduce:
- Create office365 mailbox
- Use it with django-mailbox using IMAP
- Set `DJANGO_MAILBOX_MAX_MESSAGE_SIZE`
- Expected: mails are fetched
- Actual: no mails are fetched


This is because when using Office365 IMAP, the server returns
`['1 (RFC822.SIZE 45274 UID 84)']`
instead of expected
`['1 (UID 218 RFC822.SIZE 4680)']`
