### PR TITLE
Fix malformed setting DJANGO_MAILBOX_DEFAULT_CHARSET

### DIFF
--- a/django_mailbox/utils.py
+++ b/django_mailbox/utils.py
@@ -64,7 +64,7 @@ def get_settings():
         ),
         'default_charset': getattr(
             settings,
-            'DJANGO_MAILBOX_default_charset',
+            'DJANGO_MAILBOX_DEFAULT_CHARSET',
             'iso8859-1',
         )
     }


### PR DESCRIPTION
Fixing DJANGO_MAILBOX_default_charset error, it does not detect the settings in django correctly because one part is in lower case. Changed to DJANGO_MAILBOX_DEFAULT_CHARSET.