### PR TITLE
Added maximum number of email to read and multiple mailbox names to read with `getmail` management command

### DIFF
--- a/django_mailbox/management/commands/getmail.py
+++ b/django_mailbox/management/commands/getmail.py
@@ -6,6 +6,11 @@ from django_mailbox.models import Mailbox
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('-mb', '--mailboxes', type=str, nargs='+', help='Write mailbox names')
+        parser.add_argument('-mr', '--max_read', type=int,
+                            help='Write maximum number of email to read from each mailbox')
+
     def handle(self, *args, **options):
         logging.basicConfig(level=logging.INFO)
-        Mailbox.get_new_mail_all_mailboxes(args)
+        Mailbox.get_new_mail_all_mailboxes(options)

--- a/docs/topics/polling.rst
+++ b/docs/topics/polling.rst
@@ -20,11 +20,11 @@ Using a cron job
 ----------------
 
 You can easily consume incoming mail by running the management command named
-``getmail``  (optionally with an argument of the name of the mailbox you'd like
-to get the mail for).::
+``getmail``  (optionally with an argument of the name(s) of the mailbox(es) you'd like
+to get the mail for. You can also pass maximum number of email count to read).::
 
     python manage.py getmail
-
+    python manage.py getmail --mailboxes mailbox1 mailbox2 --max_read 10
 
 .. _receiving-mail-from-exim4-or-postfix:
 


### PR DESCRIPTION
This PR: 

- Added named argument [optional] to read one or multiple mailbox from getmail command. 
Example: `python manage.py getmail -mb mailbox1 mailbox2` or `python manage.py getmail --mailboxes mailbox1 mailbox2`

- Added named argument [optional] to read maximum number of emails from mailbox. It can be used from getmail management command - 
 Example: `python manage.py getmail -mr 10` or `python manage.py getmail --max_read 10`

- Updated docs/topics/polling.rst file to guide the users for this changes.

This changes have been used in one of our live project which handles thousands of email per day. It might be helpful to other also.