### PR TITLE
Close attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dummy_project/*
 messages
 *.sqlite3
 .idea/
+venv/

--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -677,7 +677,6 @@ class Message(models.Model):
     def _rehydrate(self, msg):
         new = EmailMessage()
         settings = utils.get_settings()
-
         if msg.is_multipart():
             for header, value in msg.items():
                 new[header] = value
@@ -696,24 +695,24 @@ class Message(models.Model):
                 if encoding and encoding.lower() == 'quoted-printable':
                     # Cannot use `email.encoders.encode_quopri due to
                     # bug 14360: http://bugs.python.org/issue14360
-                    output = BytesIO()
-                    encode_quopri(
-                        BytesIO(
-                            attachment.document.read()
-                        ),
-                        output,
-                        quotetabs=True,
-                        header=False,
-                    )
-                    new.set_payload(
-                        output.getvalue().decode().replace(' ', '=20')
-                    )
+                    with open(attachment.document.path, 'rb') as f:
+                        output = BytesIO()
+                        encode_quopri(
+                            BytesIO(
+                                f.read()
+                            ),
+                            output,
+                            quotetabs=True,
+                            header=False,
+                        )
+                        new.set_payload(
+                            output.getvalue().decode().replace(' ', '=20')
+                        )
                     del new['Content-Transfer-Encoding']
                     new['Content-Transfer-Encoding'] = 'quoted-printable'
                 else:
-                    new.set_payload(
-                        attachment.document.read()
-                    )
+                    with open(attachment.document.path, 'rb') as f:
+                        new.set_payload(f.read())
                     del new['Content-Transfer-Encoding']
                     encode_base64(new)
             except MessageAttachment.DoesNotExist:
@@ -777,9 +776,8 @@ class Message(models.Model):
                 if self.eml.name.endswith('.gz'):
                     body = gzip.GzipFile(fileobj=self.eml).read()
                 else:
-                    self.eml.open()
-                    body = self.eml.file.read()
-                    self.eml.close()
+                    with self.eml.open():
+                        body = self.eml.file.read()
             else:
                 body = self.get_body()
             flat = email.message_from_bytes(body)


### PR DESCRIPTION
I'm working with LOTS of mails with attachments on them and started getting OS errors stating that too many files were open.

I changed the code so to close the files after reading them in order to avoid potential memory leaks and other unexpected behaviors.

Test passed OK.