### PR TITLE
Close connections after we are done with them

### DIFF
--- a/django_mailbox/transports/base.py
+++ b/django_mailbox/transports/base.py
@@ -9,3 +9,6 @@ class EmailTransport:
         message = email.message_from_bytes(contents)
 
         return message
+
+    def close(self):
+        pass

--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -50,8 +50,12 @@ class ImapTransport(EmailTransport):
             self.server.select()
 
     def close(self):
-        self.server.close()
-        self.server.logout()
+        try:
+            self.server.close()
+            self.server.logout()
+        except (imaplib.IMAP4.error, OSError) as  e:
+            logger.warning(f'Failed to close IMAP connection, ignoring: {e}')
+            pass
 
     def _get_all_message_ids(self):
         # Fetch all the message uids

--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -6,13 +6,6 @@ from django.conf import settings
 from .base import EmailTransport, MessageParseError
 
 
-# By default, imaplib will raise an exception if it encounters more
-# than 10k bytes; sometimes users attempt to consume mailboxes that
-# have a more, and modern computers are skookum-enough to handle just
-# a *few* more messages without causing any sort of problem.
-imaplib._MAXLINE = 1000000
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -55,6 +48,10 @@ class ImapTransport(EmailTransport):
             self.server.select(self.folder)
         else:
             self.server.select()
+
+    def close(self):
+        self.server.close()
+        self.server.logout()
 
     def _get_all_message_ids(self):
         # Fetch all the message uids


### PR DESCRIPTION
- Also remove `imaplib._MAXLINE` that has been fixed in [python3.5](https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-0-alpha-3:~:text=bpo%2D23647%3A%20Increase%20impalib%E2%80%99s%20MAXLINE%20to%20accommodate%20modern%20mailbox%20sizes.) (current min for this library is 3.8)