### PR TITLE
Partially handle iso-8859-8-i encoding

### DIFF
--- a/django_mailbox/utils.py
+++ b/django_mailbox/utils.py
@@ -78,6 +78,8 @@ def convert_header_to_unicode(header):
             return value
         if not encoding or encoding == 'unknown-8bit':
             encoding = default_charset
+        elif encoding == 'iso-8859-8-i':
+            encoding = 'iso-8859-8'
         return value.decode(encoding, 'replace')
 
     try:


### PR DESCRIPTION
Cast iso-8859-8-i to iso-8859-8 in django-mailbox/utils.py:81. However message will still create challenges downstream where it gets treated as pure ASCII while generating a warning. Still better than a crash that stops processing all further emails