### PR TITLE
fix retrieving google oauth token

### DIFF
--- a/django_mailbox/google_utils.py
+++ b/django_mailbox/google_utils.py
@@ -59,6 +59,10 @@ def google_api_get(email, url):
     if r.status_code == 401:
         # Go use the refresh token
         refresh_authorization(email)
+        # Force use of the new token
+        headers = dict(
+            Authorization="Bearer %s" % get_google_access_token(email),
+        )
         r = requests.get(url, headers=headers)
         logger.info("I got a %s", r.status_code)
     if r.status_code == 200:

--- a/django_mailbox/transports/gmail.py
+++ b/django_mailbox/transports/gmail.py
@@ -35,8 +35,10 @@ class GmailImapTransport(ImapTransport):
         access_token = None
         while access_token is None:
             try:
-                access_token = get_google_access_token(username)
+                # token refreshed here when expired
                 google_email_address = fetch_user_info(username)['email']
+                # retrieve token from db
+                access_token = get_google_access_token(username)
             except TypeError:
                 # This means that the google process took too long
                 # Trying again is the right thing to do


### PR DESCRIPTION
In case of google-oauth2, when google access_token expire, the Get new email action fail at first attempt, as the current implementation pull the token from the db, as a fix I forced the new token to be used instead.